### PR TITLE
Add skeleton for out-of-order 64‑bit CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ variable amount specified in the second source register.
 ## Superscalar Version
 
 A new experimental module `cpu64_superscalar.v` demonstrates a dual-issue pipeline. It fetches and decodes two instructions per cycle and uses a shared register file with four read ports. Minimal cross-lane hazard detection is provided via `hazard_unit_superscalar.v`.
+
+## Out-of-Order Version
+
+The file `cpu64_outoforder.v` sketches the next evolution of the design. It
+incorporates building blocks for:
+
+- Out-of-order issue using a simple issue queue and reorder buffer
+- Register renaming to eliminate false dependencies
+- A placeholder high-accuracy branch predictor (`branch_predictor_advanced.v`)
+- Multi-level cache hierarchy and MMU stubs
+- Hooks for wide SIMD/vector execution units
+
+These modules are currently minimal stubs intended to replace the older
+pipelined core as more functionality is implemented.

--- a/Verilog/branch_predictor_advanced.v
+++ b/Verilog/branch_predictor_advanced.v
@@ -1,0 +1,18 @@
+// branch_predictor_advanced.v
+// Placeholder for a high-accuracy branch predictor using TAGE, RSB, and BTB.
+module branch_predictor_advanced(
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire [63:0] pc_fetch,
+    output wire        predict_taken,
+    output wire [63:0] predict_target,
+    input  wire        update_valid,
+    input  wire [63:0] update_pc,
+    input  wire        update_taken,
+    input  wire [63:0] update_target
+);
+    // The detailed implementation is beyond the scope of this example.
+    // A simple static predictor is provided as a placeholder.
+    assign predict_taken  = 1'b0;
+    assign predict_target = pc_fetch + 64'd4;
+endmodule

--- a/Verilog/cache_hierarchy.v
+++ b/Verilog/cache_hierarchy.v
@@ -1,0 +1,13 @@
+// cache_hierarchy.v
+// Placeholder multi-level cache (L1/L2/L3) with replacement policy hooks.
+module cache_hierarchy(
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        mem_read,
+    input  wire        mem_write,
+    input  wire [63:0] addr,
+    input  wire [63:0] write_data,
+    output wire [63:0] read_data
+);
+    assign read_data = 64'b0;
+endmodule

--- a/Verilog/cpu64_outoforder.v
+++ b/Verilog/cpu64_outoforder.v
@@ -1,0 +1,98 @@
+// cpu64_outoforder.v
+// Experimental out-of-order superscalar CPU skeleton.
+// This file outlines a future direction for the design including
+// register renaming, advanced branch prediction and multi-level caches.
+
+`timescale 1ns/1ps
+module cpu64_outoforder(
+    input  wire clk,
+    input  wire rst_n
+);
+    // ----- Fetch stage with advanced branch predictor -----
+    wire [63:0] fetch_pc;
+    wire        bp_taken;
+    wire [63:0] bp_target;
+
+    branch_predictor_advanced bp_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .pc_fetch(fetch_pc),
+        .predict_taken(bp_taken),
+        .predict_target(bp_target),
+        .update_valid(1'b0),
+        .update_pc(64'b0),
+        .update_taken(1'b0),
+        .update_target(64'b0)
+    );
+
+    fetch_queue fq_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .pc_in(bp_taken ? bp_target : fetch_pc + 64'd4),
+        .pc_out(fetch_pc),
+        .instr_out(instr_fetch)
+    );
+
+    // ----- Decode and register renaming -----
+    wire [31:0] instr_fetch;
+    wire rename_ready;
+    wire [5:0] phys_src1, phys_src2, phys_dest;
+
+    register_rename rename_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .decode_instr(instr_fetch),
+        .rename_ready(rename_ready),
+        .phys_src1(phys_src1),
+        .phys_src2(phys_src2),
+        .phys_dest(phys_dest)
+    );
+
+    // ----- Issue queue -----
+    wire issue_ready;
+    issue_queue issue_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .instr(instr_fetch),
+        .phys_src1(phys_src1),
+        .phys_src2(phys_src2),
+        .phys_dest(phys_dest),
+        .ready(issue_ready)
+    );
+
+    // ----- Reorder buffer and execution units -----
+    wire commit_ready;
+    reorder_buffer rob_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .issue_ready(issue_ready),
+        .commit_ready(commit_ready)
+    );
+
+    vector_unit vec_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .issue_ready(issue_ready),
+        .commit_ready()
+    );
+
+    // ----- Memory hierarchy -----
+    wire [63:0] mem_addr, mem_write_data, mem_read_data;
+    cache_hierarchy cache_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .mem_read(1'b0),
+        .mem_write(1'b0),
+        .addr(mem_addr),
+        .write_data(mem_write_data),
+        .read_data(mem_read_data)
+    );
+
+    // MMU stub
+    mmu_unit mmu_u(
+        .clk(clk),
+        .rst_n(rst_n),
+        .virt_addr(mem_addr),
+        .phys_addr()
+    );
+endmodule

--- a/Verilog/fetch_queue.v
+++ b/Verilog/fetch_queue.v
@@ -1,0 +1,13 @@
+// fetch_queue.v
+// Simple instruction fetch queue placeholder.
+module fetch_queue(
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire [63:0] pc_in,
+    output wire [63:0] pc_out,
+    output wire [31:0] instr_out
+);
+    // For now just pass through the PC to instruction memory.
+    assign pc_out = pc_in;
+    assign instr_out = 32'b0;
+endmodule

--- a/Verilog/issue_queue.v
+++ b/Verilog/issue_queue.v
@@ -1,0 +1,13 @@
+// issue_queue.v
+// Placeholder issue queue for out-of-order scheduling.
+module issue_queue(
+    input  wire       clk,
+    input  wire       rst_n,
+    input  wire [31:0] instr,
+    input  wire [5:0]  phys_src1,
+    input  wire [5:0]  phys_src2,
+    input  wire [5:0]  phys_dest,
+    output wire        ready
+);
+    assign ready = 1'b1;
+endmodule

--- a/Verilog/mmu_unit.v
+++ b/Verilog/mmu_unit.v
@@ -1,0 +1,10 @@
+// mmu_unit.v
+// Placeholder MMU with multi-level TLB and page walker.
+module mmu_unit(
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire [63:0] virt_addr,
+    output wire [63:0] phys_addr
+);
+    assign phys_addr = virt_addr;
+endmodule

--- a/Verilog/register_rename.v
+++ b/Verilog/register_rename.v
@@ -1,0 +1,16 @@
+// register_rename.v
+// Placeholder register renaming unit with a simple free list.
+module register_rename(
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire [31:0] decode_instr,
+    output wire        rename_ready,
+    output wire [5:0]  phys_src1,
+    output wire [5:0]  phys_src2,
+    output wire [5:0]  phys_dest
+);
+    assign rename_ready = 1'b1;
+    assign phys_src1  = decode_instr[25:21];
+    assign phys_src2  = decode_instr[20:16];
+    assign phys_dest  = decode_instr[15:11];
+endmodule

--- a/Verilog/reorder_buffer.v
+++ b/Verilog/reorder_buffer.v
@@ -1,0 +1,10 @@
+// reorder_buffer.v
+// Placeholder reorder buffer for committing results in program order.
+module reorder_buffer(
+    input  wire clk,
+    input  wire rst_n,
+    input  wire issue_ready,
+    output wire commit_ready
+);
+    assign commit_ready = issue_ready;
+endmodule

--- a/Verilog/vector_unit.v
+++ b/Verilog/vector_unit.v
@@ -1,0 +1,10 @@
+// vector_unit.v
+// Placeholder wide SIMD/vector unit (e.g., AVX-512/FMA).
+module vector_unit(
+    input  wire clk,
+    input  wire rst_n,
+    input  wire issue_ready,
+    output wire commit_ready
+);
+    assign commit_ready = issue_ready;
+endmodule


### PR DESCRIPTION
## Summary
- outline an experimental `cpu64_outoforder` core
- add placeholder modules: advanced branch predictor, renaming, issue queue, ROB, caches, MMU and vector unit
- update README with notes about the out-of-order version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841298062d083268fbbedf602ebf179