### PR TITLE
Add decoder8w module and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# empty
+# 64-bit RISC-V CPU Project
+
+This repository contains an open source implementation of a high performance
+64-bit RISC-V CPU. The design is organized by major functional blocks under the
+`rtl/` directory with documentation in `docs/`.
+
+Implemented modules so far:
+- `pc_fetch` – program counter generation for instruction fetch
+- `l1_icache_64k_8w` – placeholder for the L1 instruction cache
+- `if_buffer_16` – FIFO buffer between fetch and decode
+- `decoder8w` – 8-wide instruction decoder placeholder
+
+Development follows the tasks outlined in `docs/tasks/cpu.txt`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
 Documentation for the RISC-V CPU project. This folder includes the overall
 project goals, task lists and interface specifications as development
 progresses.
+
+Module documentation:
+- [pc_fetch](pc_fetch.md)
+- [l1_icache_64k_8w](l1_icache.md)
+- [if_buffer_16](if_buffer_16.md)
+- [decoder8w](decoder8w.md)

--- a/docs/decoder8w.md
+++ b/docs/decoder8w.md
@@ -1,0 +1,27 @@
+# decoder8w Module
+
+This document describes the `decoder8w.sv` module which decodes up to eight instructions per cycle. The decoder translates 32-bit RISC-V instruction words into micro-ops used by downstream rename and issue stages.
+
+## Function
+
+`decoder8w` accepts eight instruction words accompanied by their program counters. For each instruction it outputs decoded register indices, immediate values and type information. This initial version supports a minimal subset of RV64I required for early testing.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `instr_i[7:0]` | in | 32 each | Instruction words to decode |
+| `pc_i[7:0]` | in | 64 each | Program counter of each instruction |
+| `valid_o[7:0]` | out | 1 each | Instruction decode valid |
+| `rd_arch_o[7:0][4:0]` | out | 5 each | Destination architectural register |
+| `rs1_arch_o[7:0][4:0]` | out | 5 each | Source register 1 |
+| `rs2_arch_o[7:0][4:0]` | out | 5 each | Source register 2 |
+| `imm_o[7:0][63:0]` | out | 64 each | Immediate value |
+| `func3_o[7:0][2:0]` | out | 3 each | Function 3 field |
+| `func7_o[7:0][6:0]` | out | 7 each | Function 7 field |
+| `is_branch_o[7:0]` | out | 1 each | Branch instruction flag |
+| `exception_o[7:0][2:0]` | out | 3 each | Decode exception bits |
+
+The micro-op structure will be refined as additional instructions are supported.

--- a/docs/if_buffer_16.md
+++ b/docs/if_buffer_16.md
@@ -1,0 +1,21 @@
+# if_buffer_16 Module
+
+`if_buffer_16.sv` implements a simple FIFO used between the instruction cache and
+decoder. It can store up to 16 instructions (128 bytes) and outputs two
+instructions (64 bits) per cycle.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `enq_valid` | in | 1 | Instruction available to enqueue |
+| `enq_data` | in | 64 | Two concatenated instructions |
+| `enq_ready` | out | 1 | Buffer can accept data |
+| `deq_ready` | in | 1 | Downstream stage ready |
+| `deq_valid` | out | 1 | Data available to dequeue |
+| `deq_data` | out | 64 | Two instructions read from buffer |
+
+The current implementation is a behavioral placeholder and does not model
+stall or flush signals.

--- a/docs/l1_icache.md
+++ b/docs/l1_icache.md
@@ -1,0 +1,40 @@
+# l1_icache_64k_8w Module
+
+This document describes the `l1_icache_64k_8w.sv` module located in `rtl/cache`.
+The cache stores instructions for the fetch pipeline and provides two read ports
+to support 8-byte aligned instruction fetching.
+
+## Parameters
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `LINE_BYTES` | 64 | Cache line size in bytes |
+| `ASSOC` | 8 | Associativity |
+| `SETS` | 128 | Number of sets |
+| `OFFSET_BITS` | 6 | Byte offset width |
+| `INDEX_BITS` | 7 | Set index width |
+| `TAG_BITS` | 51 | Tag width |
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `req_valid_if1` | in | 1 | Request valid for port 1 |
+| `req_addr_if1` | in | 64 | Address for port 1 |
+| `req_valid_if2` | in | 1 | Request valid for port 2 |
+| `req_addr_if2` | in | 64 | Address for port 2 |
+| `ready_if1` | out | 1 | Data ready on port 1 |
+| `data_if1` | out | 64 | Instruction data for port 1 |
+| `ready_if2` | out | 1 | Data ready on port 2 |
+| `data_if2` | out | 64 | Instruction data for port 2 |
+| `miss_addr_if1` | out | 64 | Miss address forwarded to L2 (port 1) |
+| `miss_addr_if2` | out | 64 | Miss address forwarded to L2 (port 2) |
+
+## Behavior
+
+The cache performs two tag and data lookups per cycle. On a miss the line is
+allocated in an MSHR entry (up to eight entries). Replacement uses a 7-bit
+pseudo-LRU per set. This module is a placeholder and does not implement the full
+cache logic yet.

--- a/docs/pc_fetch.md
+++ b/docs/pc_fetch.md
@@ -1,0 +1,30 @@
+# pc_fetch Module
+
+This document describes the `pc_fetch.sv` module implemented in the `rtl/fetch`
+folder. The module generates program counter addresses for the instruction
+fetch pipeline.
+
+## Function
+
+`pc_fetch` maintains the current PC and outputs two addresses each cycle to
+allow fetching two instructions in parallel from the L1 instruction cache. It
+handles branch redirection and supports a configurable reset vector.
+
+## I/O Ports
+
+| Name              | Dir   | Width | Description                              |
+|-------------------|-------|-------|------------------------------------------|
+| `clk`             | in    | 1     | Clock                                    |
+| `rst_n`           | in    | 1     | Active-low reset                         |
+| `branch_taken_i`  | in    | 1     | Redirect PC to `branch_target_i`         |
+| `branch_target_i` | in    | 64    | Branch destination address               |
+| `flush_id_i`      | in    | 4     | Reserved for future pipeline flush ID    |
+| `pc_if2_o`        | out   | 64    | Current PC value                         |
+| `pc_if1_plus8_o`  | out   | 64    | Next PC value (`PC + 8`)                 |
+
+## Behavior
+
+On reset the PC is initialized to `RESET_VECTOR`. Each cycle the PC either
+updates to `branch_target_i` if a branch was taken or increments by eight bytes
+to fetch the next pair of instructions.
+

--- a/rtl/cache/l1_icache_64k_8w.sv
+++ b/rtl/cache/l1_icache_64k_8w.sv
@@ -1,0 +1,43 @@
+// l1_icache_64k_8w.sv - 64 KB 8-way set associative instruction cache
+//
+// Purpose: Supplies two 64-bit instruction words per cycle to the fetch
+// pipeline. Supports two independent read ports and tracks misses via
+// a small MSHR. This is a behavioral placeholder model.
+
+module l1_icache_64k_8w #(
+    parameter int LINE_BYTES  = 64,
+    parameter int ASSOC       = 8,
+    parameter int SETS        = 128,
+    parameter int OFFSET_BITS = 6,
+    parameter int INDEX_BITS  = 7,
+    parameter int TAG_BITS    = 51
+)(
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        req_valid_if1,
+    input  logic [63:0] req_addr_if1,
+    input  logic        req_valid_if2,
+    input  logic [63:0] req_addr_if2,
+    output logic        ready_if1,
+    output logic [63:0] data_if1,
+    output logic        ready_if2,
+    output logic [63:0] data_if2,
+    output logic [63:0] miss_addr_if1,
+    output logic [63:0] miss_addr_if2
+);
+
+    // Simple placeholder arrays for tags and data
+    logic [TAG_BITS-1:0] tags [SETS-1:0][ASSOC-1:0];
+    logic [63:0]         data_mem [SETS-1:0][ASSOC-1:0];
+
+    // Basic ready signals
+    assign ready_if1 = 1'b1;
+    assign ready_if2 = 1'b1;
+
+    // Combinational read (no real cache behavior yet)
+    assign data_if1 = 64'h0;
+    assign data_if2 = 64'h0;
+    assign miss_addr_if1 = req_valid_if1 ? req_addr_if1 : 64'h0;
+    assign miss_addr_if2 = req_valid_if2 ? req_addr_if2 : 64'h0;
+
+endmodule

--- a/rtl/decode/README.md
+++ b/rtl/decode/README.md
@@ -1,0 +1,1 @@
+Modules for instruction decode stage.

--- a/rtl/decode/decoder8w.sv
+++ b/rtl/decode/decoder8w.sv
@@ -1,0 +1,45 @@
+// decoder8w.sv - 8-wide RISC-V instruction decoder
+//
+// Purpose: Decode up to eight 32-bit instruction words per cycle and
+// output the basic fields required by downstream rename logic. This
+// is a simplified placeholder that supports a minimal subset of RV64I
+// instructions for early integration testing.
+
+module decoder8w (
+    input  logic         clk,
+    input  logic         rst_n,
+    input  logic [31:0]  instr_i [7:0],
+    input  logic [63:0]  pc_i    [7:0],
+    output logic         valid_o    [7:0],
+    output logic [4:0]   rd_arch_o  [7:0],
+    output logic [4:0]   rs1_arch_o [7:0],
+    output logic [4:0]   rs2_arch_o [7:0],
+    output logic [63:0]  imm_o      [7:0],
+    output logic [2:0]   func3_o    [7:0],
+    output logic [6:0]   func7_o    [7:0],
+    output logic         is_branch_o[7:0],
+    output logic [2:0]   exception_o[7:0]
+);
+
+    // Simple combinational decode for a subset of instructions
+    always_comb begin
+        for (int i = 0; i < 8; i++) begin
+            logic [6:0] opcode;
+            opcode = instr_i[i][6:0];
+            valid_o[i]      = 1'b1;
+            rd_arch_o[i]    = instr_i[i][11:7];
+            rs1_arch_o[i]   = instr_i[i][19:15];
+            rs2_arch_o[i]   = instr_i[i][24:20];
+            func3_o[i]      = instr_i[i][14:12];
+            func7_o[i]      = instr_i[i][31:25];
+            imm_o[i]        = 64'd0;
+            is_branch_o[i]  = (opcode == 7'b1100011);
+            exception_o[i]  = 3'b000;
+
+            // Handle I-type immediate as a simple example
+            if (opcode == 7'b0010011 || opcode == 7'b0000011) begin
+                imm_o[i] = {{52{instr_i[i][31]}}, instr_i[i][31:20]};
+            end
+        end
+    end
+endmodule

--- a/rtl/fetch/README.md
+++ b/rtl/fetch/README.md
@@ -1,0 +1,1 @@
+Modules for instruction fetch stage.

--- a/rtl/fetch/if_buffer_16.sv
+++ b/rtl/fetch/if_buffer_16.sv
@@ -1,0 +1,43 @@
+// if_buffer_16.sv - Simple instruction fetch FIFO buffer
+//
+// Purpose: Stores up to 16 instructions (128 bytes) to decouple the
+// instruction fetch stage from downstream decode. Two instructions
+// (64 bits) may be dequeued each cycle.
+
+module if_buffer_16 (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        enq_valid,
+    input  logic [63:0] enq_data,
+    output logic        enq_ready,
+    input  logic        deq_ready,
+    output logic        deq_valid,
+    output logic [63:0] deq_data
+);
+
+    logic [63:0] fifo_mem [15:0];
+    logic [4:0]  head, tail, count;
+
+    assign enq_ready = (count < 16);
+    assign deq_valid = (count > 0);
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            head  <= 0;
+            tail  <= 0;
+            count <= 0;
+        end else begin
+            if (enq_valid && enq_ready) begin
+                fifo_mem[tail] <= enq_data;
+                tail <= tail + 1;
+                count <= count + 1;
+            end
+            if (deq_ready && deq_valid) begin
+                deq_data <= fifo_mem[head];
+                head <= head + 1;
+                count <= count - 1;
+            end
+        end
+    end
+
+endmodule

--- a/rtl/fetch/pc_fetch.sv
+++ b/rtl/fetch/pc_fetch.sv
@@ -1,0 +1,35 @@
+// pc_fetch.sv - Program counter fetch stage
+//
+// Purpose: Provide the PC generation logic for the instruction fetch
+// pipeline. On each cycle, two sequential instruction addresses are
+// produced to drive the L1 instruction cache. Handles branch redirection
+// and reset behavior.
+
+module pc_fetch (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        branch_taken_i,
+    input  logic [63:0] branch_target_i,
+    input  logic [3:0]  flush_id_i, // reserved for future use
+    output logic [63:0] pc_if2_o,
+    output logic [63:0] pc_if1_plus8_o
+);
+
+    parameter logic [63:0] RESET_VECTOR = 64'h0000_0000_8000_0000;
+
+    logic [63:0] pc_reg;
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            pc_reg <= RESET_VECTOR;
+        end else if (branch_taken_i) begin
+            pc_reg <= branch_target_i;
+        end else begin
+            pc_reg <= pc_reg + 64'd8;
+        end
+    end
+
+    assign pc_if2_o       = pc_reg;
+    assign pc_if1_plus8_o = pc_reg + 64'd8;
+
+endmodule


### PR DESCRIPTION
## Summary
- create new decoder8w module in `rtl/decode`
- document interface of decoder8w
- reference decoder module in project documentation

## Testing
- `make` *(fails: iverilog not installed)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841513a77f08326bcd5639fcd9d8eff