### PR TITLE
Add rename unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Implemented modules so far:
 - `arch_regfile_32x64` – 32×64-bit architectural register file
 - `phys_regfile_128x64` – 128×64-bit physical register file
 - `rename_unit_8wide` – simple rename unit with free list
+- `rob256` – reorder buffer placeholder
 
 Development follows the tasks outlined in `docs/tasks/cpu.txt`.

--- a/README.md
+++ b/README.md
@@ -9,5 +9,8 @@ Implemented modules so far:
 - `l1_icache_64k_8w` – placeholder for the L1 instruction cache
 - `if_buffer_16` – FIFO buffer between fetch and decode
 - `decoder8w` – 8-wide instruction decoder placeholder
+- `arch_regfile_32x64` – 32×64-bit architectural register file
+- `phys_regfile_128x64` – 128×64-bit physical register file
+- `rename_unit_8wide` – simple rename unit with free list
 
 Development follows the tasks outlined in `docs/tasks/cpu.txt`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,6 @@ Module documentation:
 - [l1_icache_64k_8w](l1_icache.md)
 - [if_buffer_16](if_buffer_16.md)
 - [decoder8w](decoder8w.md)
+- [arch_regfile_32x64](arch_regfile_32x64.md)
+- [phys_regfile_128x64](phys_regfile_128x64.md)
+- [rename_unit_8wide](rename_unit_8wide.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ Module documentation:
 - [arch_regfile_32x64](arch_regfile_32x64.md)
 - [phys_regfile_128x64](phys_regfile_128x64.md)
 - [rename_unit_8wide](rename_unit_8wide.md)
+- [rob256](rob256.md)

--- a/docs/arch_regfile_32x64.md
+++ b/docs/arch_regfile_32x64.md
@@ -1,0 +1,29 @@
+# arch_regfile_32x64 Module
+
+The `arch_regfile_32x64.sv` module implements the architectural register file
+(ARF) used by the decode and rename stages. It provides a single synchronous
+write port and three asynchronous read ports for the thirty-two 64‑bit
+registers defined by the RV64 ISA.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active‑low reset |
+| `we0` | in | 1 | Write enable for the single write port |
+| `waddr0[4:0]` | in | 5 | Register index to write |
+| `wdata0[63:0]` | in | 64 | Data to write |
+| `raddr0[4:0]` | in | 5 | Read address port 0 |
+| `rdata0[63:0]` | out | 64 | Data from port 0 |
+| `raddr1[4:0]` | in | 5 | Read address port 1 |
+| `rdata1[63:0]` | out | 64 | Data from port 1 |
+| `raddr2[4:0]` | in | 5 | Read address port 2 |
+| `rdata2[63:0]` | out | 64 | Data from port 2 |
+
+## Behavior
+
+Values written on the rising edge of `clk` appear on the selected register the
+following cycle when `we0` is asserted. Read ports are purely combinational so
+that the current value of a register is available without waiting for a clock
+edge.

--- a/docs/phys_regfile_128x64.md
+++ b/docs/phys_regfile_128x64.md
@@ -1,0 +1,38 @@
+# phys_regfile_128x64 Module
+
+The `phys_regfile_128x64.sv` module implements the physical register file used by the rename and issue stages. It stores 128 64‑bit registers and provides four synchronous write ports and six asynchronous read ports to sustain the throughput of an 8‑wide out‑of‑order pipeline.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active‑low reset |
+| `we0` | in | 1 | Write enable port 0 |
+| `waddr0[6:0]` | in | 7 | Write address port 0 |
+| `wdata0[63:0]` | in | 64 | Data for port 0 |
+| `we1` | in | 1 | Write enable port 1 |
+| `waddr1[6:0]` | in | 7 | Write address port 1 |
+| `wdata1[63:0]` | in | 64 | Data for port 1 |
+| `we2` | in | 1 | Write enable port 2 |
+| `waddr2[6:0]` | in | 7 | Write address port 2 |
+| `wdata2[63:0]` | in | 64 | Data for port 2 |
+| `we3` | in | 1 | Write enable port 3 |
+| `waddr3[6:0]` | in | 7 | Write address port 3 |
+| `wdata3[63:0]` | in | 64 | Data for port 3 |
+| `raddr0[6:0]` | in | 7 | Read address port 0 |
+| `rdata0[63:0]` | out | 64 | Data from port 0 |
+| `raddr1[6:0]` | in | 7 | Read address port 1 |
+| `rdata1[63:0]` | out | 64 | Data from port 1 |
+| `raddr2[6:0]` | in | 7 | Read address port 2 |
+| `rdata2[63:0]` | out | 64 | Data from port 2 |
+| `raddr3[6:0]` | in | 7 | Read address port 3 |
+| `rdata3[63:0]` | out | 64 | Data from port 3 |
+| `raddr4[6:0]` | in | 7 | Read address port 4 |
+| `rdata4[63:0]` | out | 64 | Data from port 4 |
+| `raddr5[6:0]` | in | 7 | Read address port 5 |
+| `rdata5[63:0]` | out | 64 | Data from port 5 |
+
+## Behavior
+
+Values written on the rising edge of `clk` appear in the register file the next cycle when the corresponding `weX` is asserted. All read ports are purely combinational to deliver register contents for issue without additional latency.

--- a/docs/rename_unit_8wide.md
+++ b/docs/rename_unit_8wide.md
@@ -1,0 +1,41 @@
+# rename_unit_8wide Module
+
+`rename_unit_8wide.sv` provides a simple register renaming implementation for
+up to eight decoded instructions each cycle. It maps architectural register
+indices to physical register indices using an internal rename table and free
+list.
+
+## Function
+
+- Maintains a mapping `arch_to_phys[31:0]`.
+- Allocates physical registers from a free list initially containing indices
+  32 through 127.
+- For each valid instruction, outputs the physical source registers and a newly
+  allocated destination register along with the previous mapping (`old_rd_phys`).
+- Allocation occurs only when the ROB and reservation stations can accept eight
+  new entries and at least eight free physical registers are available.
+
+This first version does not implement branch checkpointing or recovery.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `valid_in[7:0]` | in | 1 each | Instruction valid flags |
+| `rs1_arch_i[7:0]` | in | 5 each | Source register 1 |
+| `rs2_arch_i[7:0]` | in | 5 each | Source register 2 |
+| `rd_arch_i[7:0]` | in | 5 each | Destination register |
+| `can_allocate_rob8` | in | 1 | ROB has room for 8 entries |
+| `can_allocate_rs8` | in | 1 | Issue queue has room |
+| `rs1_phys_o[7:0]` | out | 7 each | Physical source 1 |
+| `rs2_phys_o[7:0]` | out | 7 each | Physical source 2 |
+| `rd_phys_o[7:0]` | out | 7 each | Allocated destination |
+| `old_rd_phys_o[7:0]` | out | 7 each | Previous mapping of destination |
+| `rename_valid_o[7:0]` | out | 1 each | Allocation successful |
+| `free_list_count_o` | out | 7 | Remaining free registers |
+
+`rename_unit_8wide` is a behavioral placeholder and will be extended with
+branch checkpointing and recovery logic.
+

--- a/docs/rob256.md
+++ b/docs/rob256.md
@@ -1,0 +1,40 @@
+# rob256 Module
+
+The `rob256.sv` module implements a simplified reorder buffer for the early
+OOO pipeline stages. It can allocate up to eight new entries per cycle and
+tracks completion via a writeback interface. Entries commit in program order
+when ready.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `alloc_valid_i[7:0]` | in | 1 each | Allocate new ROB entry |
+| `dest_phys_i[7:0]` | in | 7 each | Destination physical register |
+| `old_dest_phys_i[7:0]` | in | 7 each | Previous mapping |
+| `is_store_i[7:0]` | in | 1 each | Marks store operations |
+| `is_branch_i[7:0]` | in | 1 each | Marks branch operations |
+| `alloc_ready_o` | out | 1 | Indicates space for eight entries |
+| `alloc_idx_o[7:0]` | out | 8 each | Index assigned to new entry |
+| `wb_valid_i[7:0]` | in | 1 each | Writeback for completed µops |
+| `wb_idx_i[7:0]` | in | 8 each | Index of completing entry |
+| `commit_ready_i` | in | 1 | Allows commit this cycle |
+| `commit_valid_o` | out | 1 | A commit occurred |
+| `commit_idx_o[7:0]` | out | 8 | Index of committing entry |
+| `commit_rd_phys_o[6:0]` | out | 7 | Destination register |
+| `commit_old_phys_o[6:0]` | out | 7 | Previous mapping to free |
+| `commit_is_store_o` | out | 1 | Committed instruction was a store |
+| `commit_branch_misp_o` | out | 1 | Placeholder branch mispredict flag |
+
+## Behavior
+
+A circular array of 256 entries tracks all in-flight operations. When space is
+available (`alloc_ready_o`), up to eight new entries are added each cycle at the
+tail pointer. The writeback interface marks entries ready for commit. When the
+oldest valid entry is ready and `commit_ready_i` is asserted, that entry's
+information is presented on the commit outputs and the head pointer advances.
+This module is a behavioral placeholder; exception handling and branch
+checkpointing are left for later development.
+

--- a/rtl/rename/rename_unit_8wide.sv
+++ b/rtl/rename/rename_unit_8wide.sv
@@ -1,0 +1,83 @@
+// rename_unit_8wide.sv - Register renaming logic for 8-wide decode
+//
+// Purpose: Map architectural registers to physical registers using
+// a free-list and rename table. Allocates up to eight instructions
+// per cycle. This is a simplified placeholder implementation without
+// branch checkpointing or mispredict recovery.
+
+module rename_unit_8wide (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic [7:0]  valid_in,
+    input  logic [4:0]  rs1_arch_i [7:0],
+    input  logic [4:0]  rs2_arch_i [7:0],
+    input  logic [4:0]  rd_arch_i  [7:0],
+    input  logic        can_allocate_rob8,
+    input  logic        can_allocate_rs8,
+    output logic [6:0]  rs1_phys_o [7:0],
+    output logic [6:0]  rs2_phys_o [7:0],
+    output logic [6:0]  rd_phys_o  [7:0],
+    output logic [6:0]  old_rd_phys_o [7:0],
+    output logic [7:0]  rename_valid_o,
+    output logic [6:0]  free_list_count_o
+);
+
+    parameter int PHYS_REGS = 128;
+    parameter int ARCH_REGS = 32;
+    parameter int FREE_LIST_SIZE = PHYS_REGS - ARCH_REGS;
+
+    // Mapping table arch -> phys
+    logic [6:0] arch_to_phys [ARCH_REGS-1:0];
+
+    // Free list implemented as circular buffer
+    logic [6:0] free_list   [FREE_LIST_SIZE-1:0];
+    logic [6:0] free_head, free_tail;
+    logic [6:0] free_count;
+
+    assign free_list_count_o = free_count;
+
+    // Initial setup
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (int i = 0; i < ARCH_REGS; i++) begin
+                arch_to_phys[i] <= i[6:0];
+            end
+            for (int j = 0; j < FREE_LIST_SIZE; j++) begin
+                free_list[j] <= ARCH_REGS + j;
+            end
+            free_head <= 0;
+            free_tail <= 0;
+            free_count <= FREE_LIST_SIZE[6:0];
+        end else begin
+            // Allocate new physical registers when enabled
+            if (can_allocate_rob8 && can_allocate_rs8 && free_count >= 8) begin
+                for (int k = 0; k < 8; k++) begin
+                    if (valid_in[k]) begin
+                        old_rd_phys_o[k] <= arch_to_phys[rd_arch_i[k]];
+                        rd_phys_o[k]     <= free_list[free_head];
+                        arch_to_phys[rd_arch_i[k]] <= free_list[free_head];
+                        free_head <= free_head + 1;
+                        free_count <= free_count - 1;
+                        rename_valid_o[k] <= 1'b1;
+                    end else begin
+                        old_rd_phys_o[k] <= arch_to_phys[rd_arch_i[k]];
+                        rd_phys_o[k]     <= arch_to_phys[rd_arch_i[k]];
+                        rename_valid_o[k] <= 1'b0;
+                    end
+                    rs1_phys_o[k] <= arch_to_phys[rs1_arch_i[k]];
+                    rs2_phys_o[k] <= arch_to_phys[rs2_arch_i[k]];
+                end
+            end else begin
+                // Not enough resources: outputs invalid
+                for (int m = 0; m < 8; m++) begin
+                    rs1_phys_o[m]     <= arch_to_phys[rs1_arch_i[m]];
+                    rs2_phys_o[m]     <= arch_to_phys[rs2_arch_i[m]];
+                    rd_phys_o[m]      <= arch_to_phys[rd_arch_i[m]];
+                    old_rd_phys_o[m]  <= arch_to_phys[rd_arch_i[m]];
+                    rename_valid_o[m] <= 1'b0;
+                end
+            end
+        end
+    end
+
+endmodule

--- a/rtl/rf/arch_regfile_32x64.sv
+++ b/rtl/rf/arch_regfile_32x64.sv
@@ -1,0 +1,39 @@
+// arch_regfile_32x64.sv - Architectural Register File
+//
+// Purpose: Implements the 32 x 64-bit architectural register file used by
+// the decode and rename stages. The module provides one synchronous write
+// port and three asynchronous read ports.
+
+module arch_regfile_32x64 (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        we0,
+    input  logic [4:0]  waddr0,
+    input  logic [63:0] wdata0,
+    input  logic [4:0]  raddr0,
+    output logic [63:0] rdata0,
+    input  logic [4:0]  raddr1,
+    output logic [63:0] rdata1,
+    input  logic [4:0]  raddr2,
+    output logic [63:0] rdata2
+);
+
+    logic [63:0] regfile [31:0];
+
+    // Synchronous write
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (int i = 0; i < 32; i++) begin
+                regfile[i] <= 64'd0;
+            end
+        end else if (we0) begin
+            regfile[waddr0] <= wdata0;
+        end
+    end
+
+    // Asynchronous reads
+    assign rdata0 = regfile[raddr0];
+    assign rdata1 = regfile[raddr1];
+    assign rdata2 = regfile[raddr2];
+
+endmodule

--- a/rtl/rf/phys_regfile_128x64.sv
+++ b/rtl/rf/phys_regfile_128x64.sv
@@ -1,0 +1,61 @@
+// phys_regfile_128x64.sv - Physical Register File
+//
+// Purpose: Stores 128 64-bit registers for the out-of-order backend. The module
+// provides four synchronous write ports and six asynchronous read ports to
+// support up to eight instructions in flight each cycle.
+
+(* clock_gating_cell = "yes" *)
+module phys_regfile_128x64 (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        we0,
+    input  logic [6:0]  waddr0,
+    input  logic [63:0] wdata0,
+    input  logic        we1,
+    input  logic [6:0]  waddr1,
+    input  logic [63:0] wdata1,
+    input  logic        we2,
+    input  logic [6:0]  waddr2,
+    input  logic [63:0] wdata2,
+    input  logic        we3,
+    input  logic [6:0]  waddr3,
+    input  logic [63:0] wdata3,
+    input  logic [6:0]  raddr0,
+    output logic [63:0] rdata0,
+    input  logic [6:0]  raddr1,
+    output logic [63:0] rdata1,
+    input  logic [6:0]  raddr2,
+    output logic [63:0] rdata2,
+    input  logic [6:0]  raddr3,
+    output logic [63:0] rdata3,
+    input  logic [6:0]  raddr4,
+    output logic [63:0] rdata4,
+    input  logic [6:0]  raddr5,
+    output logic [63:0] rdata5
+);
+
+    logic [63:0] regfile [127:0];
+
+    // Synchronous writes
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (int i = 0; i < 128; i++) begin
+                regfile[i] <= 64'd0;
+            end
+        end else begin
+            if (we0) regfile[waddr0] <= wdata0;
+            if (we1) regfile[waddr1] <= wdata1;
+            if (we2) regfile[waddr2] <= wdata2;
+            if (we3) regfile[waddr3] <= wdata3;
+        end
+    end
+
+    // Asynchronous reads
+    assign rdata0 = regfile[raddr0];
+    assign rdata1 = regfile[raddr1];
+    assign rdata2 = regfile[raddr2];
+    assign rdata3 = regfile[raddr3];
+    assign rdata4 = regfile[raddr4];
+    assign rdata5 = regfile[raddr5];
+
+endmodule

--- a/rtl/rob_rs_iq/rob256.sv
+++ b/rtl/rob_rs_iq/rob256.sv
@@ -1,0 +1,107 @@
+// rob256.sv - Reorder Buffer with 256 entries
+//
+// Purpose: Tracks in-flight micro-operations and commits them in program
+// order. Simplified placeholder supporting up to eight allocations and
+// eight writebacks per cycle.
+
+module rob256 (
+    input  logic        clk,
+    input  logic        rst_n,
+
+    // Allocate up to eight new entries per cycle
+    input  logic [7:0]  alloc_valid_i,
+    input  logic [6:0]  dest_phys_i      [7:0],
+    input  logic [6:0]  old_dest_phys_i  [7:0],
+    input  logic [7:0]  is_store_i,
+    input  logic [7:0]  is_branch_i,
+    output logic        alloc_ready_o,
+    output logic [7:0]  alloc_idx_o      [7:0],
+
+    // Writeback results
+    input  logic [7:0]  wb_valid_i,
+    input  logic [7:0]  wb_idx_i      [7:0],
+
+    // Commit interface
+    input  logic        commit_ready_i,
+    output logic        commit_valid_o,
+    output logic [7:0]  commit_idx_o,
+    output logic [6:0]  commit_rd_phys_o,
+    output logic [6:0]  commit_old_phys_o,
+    output logic        commit_is_store_o,
+    output logic        commit_branch_misp_o
+);
+
+    localparam int ROB_ENTRIES = 256;
+    typedef struct packed {
+        logic        valid;
+        logic        ready;
+        logic [6:0]  dest_phys;
+        logic [6:0]  old_dest_phys;
+        logic        is_store;
+        logic        is_branch;
+    } rob_entry_t;
+
+    rob_entry_t rob[ROB_ENTRIES-1:0];
+    logic [7:0] head_ptr, tail_ptr;
+    logic [8:0] count;
+
+    assign alloc_ready_o = (count <= ROB_ENTRIES-8);
+
+    // Allocate new entries
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            head_ptr <= 0;
+            tail_ptr <= 0;
+            count    <= 0;
+            for (int i = 0; i < ROB_ENTRIES; i++) begin
+                rob[i].valid <= 1'b0;
+                rob[i].ready <= 1'b0;
+                rob[i].dest_phys <= '0;
+                rob[i].old_dest_phys <= '0;
+                rob[i].is_store <= 1'b0;
+                rob[i].is_branch <= 1'b0;
+            end
+        end else begin
+            if (alloc_ready_o) begin
+                for (int j = 0; j < 8; j++) begin
+                    if (alloc_valid_i[j]) begin
+                        rob[tail_ptr].valid        <= 1'b1;
+                        rob[tail_ptr].ready        <= 1'b0;
+                        rob[tail_ptr].dest_phys    <= dest_phys_i[j];
+                        rob[tail_ptr].old_dest_phys<= old_dest_phys_i[j];
+                        rob[tail_ptr].is_store     <= is_store_i[j];
+                        rob[tail_ptr].is_branch    <= is_branch_i[j];
+                        alloc_idx_o[j]             <= tail_ptr;
+                        tail_ptr <= tail_ptr + 1;
+                        count    <= count + 1;
+                    end else begin
+                        alloc_idx_o[j] <= tail_ptr;
+                    end
+                end
+            end
+
+            // Mark entries ready on writeback
+            for (int k = 0; k < 8; k++) begin
+                if (wb_valid_i[k]) begin
+                    rob[wb_idx_i[k]].ready <= 1'b1;
+                end
+            end
+
+            // Commit oldest entry when ready
+            if (commit_ready_i && rob[head_ptr].valid && rob[head_ptr].ready) begin
+                commit_valid_o      <= 1'b1;
+                commit_idx_o        <= head_ptr;
+                commit_rd_phys_o    <= rob[head_ptr].dest_phys;
+                commit_old_phys_o   <= rob[head_ptr].old_dest_phys;
+                commit_is_store_o   <= rob[head_ptr].is_store;
+                commit_branch_misp_o<= 1'b0;
+                rob[head_ptr].valid <= 1'b0;
+                head_ptr <= head_ptr + 1;
+                count    <= count - 1;
+            end else begin
+                commit_valid_o <= 1'b0;
+            end
+        end
+    end
+
+endmodule


### PR DESCRIPTION
## Summary
- implement `rename_unit_8wide` module for register renaming
- document rename unit and link from docs index
- mention module in top-level README

## Testing
- `make` *(fails: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68415671cfec8326bdcc83a0191ccc65