### PR TITLE
Add atomic unit and RV64A support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,9 @@ Implemented modules so far:
 - `phys_regfile_128x64` – 128×64-bit physical register file
 - `rename_unit_8wide` – simple rename unit with free list
 - `rob256` – reorder buffer placeholder
+- `int_alu2` – dual one-cycle integer ALU pipelines
+- `muldiv_unit` – pipelined multiply/divide unit
+- `branch_unit` – resolves branches and detects mispredictions
+- `amo_unit` – executes basic atomic operations
 
 Development follows the tasks outlined in `docs/tasks/cpu.txt`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,5 @@ Module documentation:
 - [phys_regfile_128x64](phys_regfile_128x64.md)
 - [rename_unit_8wide](rename_unit_8wide.md)
 - [rob256](rob256.md)
+- [branch_unit](branch_unit.md)
+- [amo_unit](amo_unit.md)

--- a/docs/amo_unit.md
+++ b/docs/amo_unit.md
@@ -1,0 +1,26 @@
+# amo_unit Module
+
+`amo_unit.sv` resides in `rtl/ex_units/` and executes atomic memory
+operations from the RV64A extension. The unit is a placeholder that
+performs the arithmetic portion of AMOs and relies on the load/store
+unit to handle memory ordering.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `valid_i` | in | 1 | Operation valid |
+| `op_a_i` | in | 64 | Value loaded from memory |
+| `op_b_i` | in | 64 | Register operand |
+| `amo_funct_i` | in | 3 | AMO function code |
+| `result_o` | out | 64 | Computed result |
+| `ready_o` | out | 1 | Result valid |
+
+## Behavior
+
+Given the loaded value and register operand, the unit performs the
+specified operation (swap or add currently) and outputs the result on
+the next cycle. The design is intentionally simple for early
+integration tests.

--- a/docs/branch_unit.md
+++ b/docs/branch_unit.md
@@ -1,0 +1,32 @@
+# branch_unit Module
+
+The `branch_unit.sv` module resides in `rtl/ex_units/` and resolves both
+conditional and unconditional branches in a single cycle.
+
+## Parameters
+
+This unit does not expose parameters beyond the standard interface.
+
+## I/O Ports
+
+| Name | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | Clock |
+| `rst_n` | in | 1 | Active-low reset |
+| `pc_ex_i` | in | 64 | Program counter at execute stage |
+| `rs1_val_i` | in | 64 | First operand value |
+| `rs2_val_i` | in | 64 | Second operand value |
+| `branch_ctrl_i` | in | 3 | Branch type selector |
+| `target_imm_i` | in | 32 | Sign-extended branch immediate |
+| `predicted_taken_i` | in | 1 | Predictor taken flag |
+| `predicted_target_i` | in | 64 | Predicted branch target |
+| `actual_taken_o` | out | 1 | Actual taken result |
+| `actual_target_o` | out | 64 | Actual branch target |
+| `pred_mispredict_o` | out | 1 | High when prediction was incorrect |
+
+## Behavior
+
+Given operand values and a branch control code, the unit compares the
+operands according to the branch type and produces an actual target
+address. It also reports whether a misprediction occurred based on the
+predicted inputs. All outputs are valid one cycle after the inputs.

--- a/docs/golden_model.md
+++ b/docs/golden_model.md
@@ -5,12 +5,14 @@ implementation of a 64‑bit RISC‑V interpreter. It is not cycle accurate but
 implements a minimal subset of RV64I so that UVM testbenches can compare
 results against expected behavior.
 
-Currently supported instructions:
+Currently supported instructions include:
 
-- `ADD`, `SUB`
-- `ADDI`
-- `LW` and `SW` (modeled as 64‑bit word accesses)
-- `BEQ`, `BNE`
+- Integer ALU operations (`ADD`, `SUB`, `ADDI`)
+- Load/store (`LW`, `SW` simplified as 64‑bit accesses)
+- Branches (`BEQ`, `BNE`, `BLT`, `BGE`, `BLTU`, `BGEU`)
+- Jumps (`JAL`, `JALR`)
+- Multiply/divide (`MUL`, `DIV`, `REM` and variants)
+- Basic atomic operations (`LR.D`, `SC.D`, `AMOADD.D`, `AMOSWAP.D`)
 
 The `GoldenModel` class maintains an array of 32 general purpose registers,
 a dictionary based memory and the current program counter. The `step` method

--- a/rtl/ex_units/README.md
+++ b/rtl/ex_units/README.md
@@ -1,0 +1,5 @@
+Execution units for the pipeline including:
+- `int_alu2.sv` dual one-cycle integer ALU pipelines
+- `muldiv_unit.sv` 3-stage multiplier and 20-stage divider
+- `branch_unit.sv` single-cycle branch resolution unit
+- `amo_unit.sv` atomic arithmetic operations

--- a/rtl/ex_units/amo_unit.sv
+++ b/rtl/ex_units/amo_unit.sv
@@ -1,0 +1,43 @@
+// amo_unit.sv - Atomic memory operation execution unit
+//
+// Purpose: Execute basic atomic arithmetic operations for the RV64A
+// extension. This placeholder model handles AMOADD.D and AMOSWAP.D in a
+// single cycle. Memory access sequencing is expected to be managed by the
+// load/store unit.
+
+module amo_unit(
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        valid_i,
+    input  logic [63:0] op_a_i,
+    input  logic [63:0] op_b_i,
+    input  logic [2:0]  amo_funct_i, // 0=add,1=swap
+    output logic        ready_o,
+    output logic [63:0] result_o
+);
+
+    logic [63:0] result_next;
+
+    always_comb begin
+        case (amo_funct_i)
+            3'd0: result_next = op_a_i + op_b_i;  // AMOADD
+            3'd1: result_next = op_b_i;           // AMOSWAP
+            default: result_next = op_a_i;
+        endcase
+    end
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            result_o <= 64'd0;
+            ready_o  <= 1'b0;
+        end else begin
+            if (valid_i) begin
+                result_o <= result_next;
+                ready_o  <= 1'b1;
+            end else begin
+                ready_o  <= 1'b0;
+            end
+        end
+    end
+
+endmodule

--- a/rtl/ex_units/branch_unit.sv
+++ b/rtl/ex_units/branch_unit.sv
@@ -1,0 +1,57 @@
+// branch_unit.sv - Branch execution unit
+//
+// Purpose: Resolve conditional and unconditional branches in a single
+// cycle. Computes the actual target and whether the branch is taken,
+// comparing the result against the predicted target to detect
+// mispredictions.
+
+module branch_unit(
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic [63:0] pc_ex_i,
+    input  logic [63:0] rs1_val_i,
+    input  logic [63:0] rs2_val_i,
+    input  logic [2:0]  branch_ctrl_i,   // BEQ=0,BNE=1,BLT=2,BGE=3,BLTU=4,BGEU=5,JAL=6,JALR=7
+    input  logic [31:0] target_imm_i,    // sign extended immediate
+    input  logic        predicted_taken_i,
+    input  logic [63:0] predicted_target_i,
+    output logic        actual_taken_o,
+    output logic [63:0] actual_target_o,
+    output logic        pred_mispredict_o
+);
+
+    // Combinational branch resolution
+    logic [63:0] target;
+    logic taken;
+
+    always_comb begin
+        target = pc_ex_i + $signed(target_imm_i);
+        taken  = 1'b0;
+        unique case (branch_ctrl_i)
+            3'd0: taken = (rs1_val_i == rs2_val_i);      // BEQ
+            3'd1: taken = (rs1_val_i != rs2_val_i);      // BNE
+            3'd2: taken = ($signed(rs1_val_i) <  $signed(rs2_val_i)); // BLT
+            3'd3: taken = ($signed(rs1_val_i) >= $signed(rs2_val_i)); // BGE
+            3'd4: taken = (rs1_val_i < rs2_val_i);       // BLTU
+            3'd5: taken = (rs1_val_i >= rs2_val_i);      // BGEU
+            3'd6: begin                                  // JAL
+                taken  = 1'b1;
+                target = pc_ex_i + $signed(target_imm_i);
+            end
+            3'd7: begin                                  // JALR
+                taken  = 1'b1;
+                target = (rs1_val_i + $signed(target_imm_i)) & 64'hFFFF_FFFF_FFFF_FFFE;
+            end
+            default: begin
+                taken  = 1'b0;
+                target = pc_ex_i + 64'd4;
+            end
+        endcase
+    end
+
+    assign actual_taken_o   = taken;
+    assign actual_target_o  = taken ? target : pc_ex_i + 64'd4;
+    assign pred_mispredict_o = (predicted_taken_i != actual_taken_o) ||
+                               (predicted_taken_i && actual_taken_o && predicted_target_i != actual_target_o);
+
+endmodule

--- a/rtl/ex_units/int_alu2.sv
+++ b/rtl/ex_units/int_alu2.sv
@@ -1,0 +1,107 @@
+// int_alu2.sv - Dual 64-bit integer ALU pipelines
+//
+// Purpose: Provides two parallel one-cycle integer ALU pipes used during
+// execute stages. Each pipe accepts operands and an ALU operation code and
+// returns the result along with destination register bookkeeping.
+
+module int_alu2 (
+    input  logic        clk,
+    input  logic        rst_n,
+
+    // Pipeline 0 inputs
+    input  logic        valid0_i,
+    input  logic [63:0] op1_0_i,
+    input  logic [63:0] op2_0_i,
+    input  logic [3:0]  alu_ctrl_0_i,
+    input  logic [6:0]  dest_phys_0_i,
+    input  logic [7:0]  rob_idx_0_i,
+
+    // Pipeline 1 inputs
+    input  logic        valid1_i,
+    input  logic [63:0] op1_1_i,
+    input  logic [63:0] op2_1_i,
+    input  logic [3:0]  alu_ctrl_1_i,
+    input  logic [6:0]  dest_phys_1_i,
+    input  logic [7:0]  rob_idx_1_i,
+
+    // Pipeline 0 outputs (valid one cycle later)
+    output logic        valid0_o,
+    output logic [63:0] result_0_o,
+    output logic [6:0]  dest_phys_0_o,
+    output logic [7:0]  rob_idx_0_o,
+
+    // Pipeline 1 outputs (valid one cycle later)
+    output logic        valid1_o,
+    output logic [63:0] result_1_o,
+    output logic [6:0]  dest_phys_1_o,
+    output logic [7:0]  rob_idx_1_o
+);
+
+    // ALU operation codes
+    localparam logic [3:0]
+        ALU_ADD  = 4'd0,
+        ALU_SUB  = 4'd1,
+        ALU_AND  = 4'd2,
+        ALU_OR   = 4'd3,
+        ALU_XOR  = 4'd4,
+        ALU_SLL  = 4'd5,
+        ALU_SRL  = 4'd6,
+        ALU_SRA  = 4'd7;
+
+    // Combinational ALU logic for pipe 0
+    logic [63:0] result0;
+    always_comb begin
+        unique case (alu_ctrl_0_i)
+            ALU_ADD: result0 = op1_0_i + op2_0_i;
+            ALU_SUB: result0 = op1_0_i - op2_0_i;
+            ALU_AND: result0 = op1_0_i & op2_0_i;
+            ALU_OR : result0 = op1_0_i | op2_0_i;
+            ALU_XOR: result0 = op1_0_i ^ op2_0_i;
+            ALU_SLL: result0 = op1_0_i << op2_0_i[5:0];
+            ALU_SRL: result0 = op1_0_i >> op2_0_i[5:0];
+            ALU_SRA: result0 = $signed(op1_0_i) >>> op2_0_i[5:0];
+            default: result0 = 64'd0;
+        endcase
+    end
+
+    // Combinational ALU logic for pipe 1
+    logic [63:0] result1;
+    always_comb begin
+        unique case (alu_ctrl_1_i)
+            ALU_ADD: result1 = op1_1_i + op2_1_i;
+            ALU_SUB: result1 = op1_1_i - op2_1_i;
+            ALU_AND: result1 = op1_1_i & op2_1_i;
+            ALU_OR : result1 = op1_1_i | op2_1_i;
+            ALU_XOR: result1 = op1_1_i ^ op2_1_i;
+            ALU_SLL: result1 = op1_1_i << op2_1_i[5:0];
+            ALU_SRL: result1 = op1_1_i >> op2_1_i[5:0];
+            ALU_SRA: result1 = $signed(op1_1_i) >>> op2_1_i[5:0];
+            default: result1 = 64'd0;
+        endcase
+    end
+
+    // Pipeline registers
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            valid0_o      <= 1'b0;
+            result_0_o    <= 64'd0;
+            dest_phys_0_o <= 7'd0;
+            rob_idx_0_o   <= 8'd0;
+            valid1_o      <= 1'b0;
+            result_1_o    <= 64'd0;
+            dest_phys_1_o <= 7'd0;
+            rob_idx_1_o   <= 8'd0;
+        end else begin
+            valid0_o      <= valid0_i;
+            result_0_o    <= result0;
+            dest_phys_0_o <= dest_phys_0_i;
+            rob_idx_0_o   <= rob_idx_0_i;
+
+            valid1_o      <= valid1_i;
+            result_1_o    <= result1;
+            dest_phys_1_o <= dest_phys_1_i;
+            rob_idx_1_o   <= rob_idx_1_i;
+        end
+    end
+
+endmodule

--- a/rtl/ex_units/muldiv_unit.sv
+++ b/rtl/ex_units/muldiv_unit.sv
@@ -1,0 +1,101 @@
+// muldiv_unit.sv - 64-bit multiply/divide execution unit
+//
+// Purpose: Provides a 3-stage pipelined multiplier and a 20-stage
+// divider used by the execution stages. Operations are issued
+// independently for multiply and divide. Results are returned with
+// associated destination register and ROB index after the
+// appropriate latency.
+
+module muldiv_unit #(
+    parameter int MUL_STAGES = 3,
+    parameter int DIV_STAGES = 20
+) (
+    input  logic        clk,
+    input  logic        rst_n,
+
+    // Multiply input
+    input  logic        mul_valid_i,
+    input  logic [63:0] mul_op_a_i,
+    input  logic [63:0] mul_op_b_i,
+    input  logic [6:0]  mul_dest_phys_i,
+    input  logic [7:0]  mul_rob_idx_i,
+
+    // Divide input
+    input  logic        div_valid_i,
+    input  logic [63:0] div_dividend_i,
+    input  logic [63:0] div_divisor_i,
+    input  logic [6:0]  div_dest_phys_i,
+    input  logic [7:0]  div_rob_idx_i,
+
+    // Multiply output (valid after 3 cycles)
+    output logic        mul_valid_o,
+    output logic [63:0] mul_result_o,
+    output logic [6:0]  mul_dest_phys_o,
+    output logic [7:0]  mul_rob_idx_o,
+
+    // Divide output (valid after 20 cycles)
+    output logic        div_valid_o,
+    output logic [63:0] div_result_o,
+    output logic [6:0]  div_dest_phys_o,
+    output logic [7:0]  div_rob_idx_o
+);
+
+    // Multiply pipeline registers
+    logic [MUL_STAGES-1:0]        mul_valid_pipe;
+    logic [63:0]                  mul_result_pipe [MUL_STAGES-1:0];
+    logic [6:0]                   mul_dest_pipe   [MUL_STAGES-1:0];
+    logic [7:0]                   mul_rob_pipe    [MUL_STAGES-1:0];
+
+    // Divide pipeline registers
+    logic [DIV_STAGES-1:0]        div_valid_pipe;
+    logic [63:0]                  div_result_pipe [DIV_STAGES-1:0];
+    logic [6:0]                   div_dest_pipe   [DIV_STAGES-1:0];
+    logic [7:0]                   div_rob_pipe    [DIV_STAGES-1:0];
+
+    // Shift pipelines
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            mul_valid_pipe <= '0;
+            div_valid_pipe <= '0;
+        end else begin
+            // Multiply pipeline stage 0 computation
+            mul_valid_pipe[0]  <= mul_valid_i;
+            mul_result_pipe[0] <= mul_op_a_i * mul_op_b_i;
+            mul_dest_pipe[0]   <= mul_dest_phys_i;
+            mul_rob_pipe[0]    <= mul_rob_idx_i;
+
+            // Divide pipeline stage 0 computation
+            div_valid_pipe[0]  <= div_valid_i;
+            div_result_pipe[0] <= (div_divisor_i == 0) ? 64'd0 : div_dividend_i / div_divisor_i;
+            div_dest_pipe[0]   <= div_dest_phys_i;
+            div_rob_pipe[0]    <= div_rob_idx_i;
+
+            // Shift remaining multiply pipeline stages
+            for (int i = 1; i < MUL_STAGES; i++) begin
+                mul_valid_pipe[i]  <= mul_valid_pipe[i-1];
+                mul_result_pipe[i] <= mul_result_pipe[i-1];
+                mul_dest_pipe[i]   <= mul_dest_pipe[i-1];
+                mul_rob_pipe[i]    <= mul_rob_pipe[i-1];
+            end
+
+            // Shift remaining divide pipeline stages
+            for (int j = 1; j < DIV_STAGES; j++) begin
+                div_valid_pipe[j]  <= div_valid_pipe[j-1];
+                div_result_pipe[j] <= div_result_pipe[j-1];
+                div_dest_pipe[j]   <= div_dest_pipe[j-1];
+                div_rob_pipe[j]    <= div_rob_pipe[j-1];
+            end
+        end
+    end
+
+    assign mul_valid_o      = mul_valid_pipe[MUL_STAGES-1];
+    assign mul_result_o     = mul_result_pipe[MUL_STAGES-1];
+    assign mul_dest_phys_o  = mul_dest_pipe[MUL_STAGES-1];
+    assign mul_rob_idx_o    = mul_rob_pipe[MUL_STAGES-1];
+
+    assign div_valid_o      = div_valid_pipe[DIV_STAGES-1];
+    assign div_result_o     = div_result_pipe[DIV_STAGES-1];
+    assign div_dest_phys_o  = div_dest_pipe[DIV_STAGES-1];
+    assign div_rob_idx_o    = div_rob_pipe[DIV_STAGES-1];
+
+endmodule

--- a/rtl/isa/golden_model.py
+++ b/rtl/isa/golden_model.py
@@ -5,6 +5,7 @@ class GoldenModel:
         self.regs = [0] * 32
         self.mem = {}
         self.pc = pc
+        self._reservation = None
 
     def load_memory(self, addr, data):
         """Load 64-bit word at addr."""
@@ -18,6 +19,10 @@ class GoldenModel:
         mask = 1 << (bits - 1)
         return (value & (mask - 1)) - (value & mask)
 
+    @staticmethod
+    def _to_signed(val):
+        return val if val < 2**63 else val - 2**64
+
     def step(self, instr):
         opcode = instr & 0x7F
         rd = (instr >> 7) & 0x1F
@@ -30,10 +35,63 @@ class GoldenModel:
         taken = False
 
         if opcode == 0x33:  # R-type
-            if funct3 == 0x0 and funct7 == 0x00:  # ADD
+            if funct7 == 0x00 and funct3 == 0x0:  # ADD
                 self.regs[rd] = (self.regs[rs1] + self.regs[rs2]) & 0xFFFFFFFFFFFFFFFF
-            elif funct3 == 0x0 and funct7 == 0x20:  # SUB
+            elif funct7 == 0x20 and funct3 == 0x0:  # SUB
                 self.regs[rd] = (self.regs[rs1] - self.regs[rs2]) & 0xFFFFFFFFFFFFFFFF
+            elif funct7 == 0x01:  # RV64M extension
+                if funct3 == 0x0:  # MUL
+                    self.regs[rd] = (self.regs[rs1] * self.regs[rs2]) & 0xFFFFFFFFFFFFFFFF
+                elif funct3 == 0x1:  # MULH
+                    a = self.regs[rs1]
+                    b = self.regs[rs2]
+                    a_s = a if a < 2**63 else a - 2**64
+                    b_s = b if b < 2**63 else b - 2**64
+                    res = (a_s * b_s) >> 64
+                    self.regs[rd] = res & 0xFFFFFFFFFFFFFFFF
+                elif funct3 == 0x2:  # MULHSU
+                    a = self.regs[rs1]
+                    b = self.regs[rs2]
+                    a_s = a if a < 2**63 else a - 2**64
+                    res = (a_s * b) >> 64
+                    self.regs[rd] = res & 0xFFFFFFFFFFFFFFFF
+                elif funct3 == 0x3:  # MULHU
+                    a = self.regs[rs1]
+                    b = self.regs[rs2]
+                    res = (a * b) >> 64
+                    self.regs[rd] = res & 0xFFFFFFFFFFFFFFFF
+                elif funct3 == 0x4:  # DIV
+                    dividend = self.regs[rs1]
+                    divisor = self.regs[rs2]
+                    if divisor == 0:
+                        self.regs[rd] = 0xFFFFFFFFFFFFFFFF
+                    else:
+                        dividend_s = dividend if dividend < 2**63 else dividend - 2**64
+                        divisor_s = divisor if divisor < 2**63 else divisor - 2**64
+                        self.regs[rd] = (int(dividend_s / divisor_s) & 0xFFFFFFFFFFFFFFFF)
+                elif funct3 == 0x5:  # DIVU
+                    dividend = self.regs[rs1]
+                    divisor = self.regs[rs2]
+                    if divisor == 0:
+                        self.regs[rd] = 0xFFFFFFFFFFFFFFFF
+                    else:
+                        self.regs[rd] = (dividend // divisor) & 0xFFFFFFFFFFFFFFFF
+                elif funct3 == 0x6:  # REM
+                    dividend = self.regs[rs1]
+                    divisor = self.regs[rs2]
+                    if divisor == 0:
+                        self.regs[rd] = dividend & 0xFFFFFFFFFFFFFFFF
+                    else:
+                        dividend_s = dividend if dividend < 2**63 else dividend - 2**64
+                        divisor_s = divisor if divisor < 2**63 else divisor - 2**64
+                        self.regs[rd] = (int(dividend_s % divisor_s) & 0xFFFFFFFFFFFFFFFF)
+                elif funct3 == 0x7:  # REMU
+                    dividend = self.regs[rs1]
+                    divisor = self.regs[rs2]
+                    if divisor == 0:
+                        self.regs[rd] = dividend & 0xFFFFFFFFFFFFFFFF
+                    else:
+                        self.regs[rd] = (dividend % divisor) & 0xFFFFFFFFFFFFFFFF
         elif opcode == 0x13:  # ADDI
             imm = self._sign_extend(instr >> 20, 12)
             self.regs[rd] = (self.regs[rs1] + imm) & 0xFFFFFFFFFFFFFFFF
@@ -55,8 +113,50 @@ class GoldenModel:
                 taken = self.regs[rs1] == self.regs[rs2]
             elif funct3 == 0x1:  # BNE
                 taken = self.regs[rs1] != self.regs[rs2]
+            elif funct3 == 0x4:  # BLT
+                taken = self._to_signed(self.regs[rs1]) < self._to_signed(self.regs[rs2])
+            elif funct3 == 0x5:  # BGE
+                taken = self._to_signed(self.regs[rs1]) >= self._to_signed(self.regs[rs2])
+            elif funct3 == 0x6:  # BLTU
+                taken = self.regs[rs1] < self.regs[rs2]
+            elif funct3 == 0x7:  # BGEU
+                taken = self.regs[rs1] >= self.regs[rs2]
             if taken:
                 next_pc = (self.pc + imm) & 0xFFFFFFFFFFFFFFFF
+        elif opcode == 0x6F:  # JAL
+            imm = ((instr >> 21) & 0x3FF) | ((instr >> 20) & 0x1) << 10
+            imm |= ((instr >> 12) & 0xFF) << 11
+            imm |= (instr >> 31) << 19
+            imm = self._sign_extend(imm << 1, 21)
+            self.regs[rd] = (self.pc + 4) & 0xFFFFFFFFFFFFFFFF
+            next_pc = (self.pc + imm) & 0xFFFFFFFFFFFFFFFF
+        elif opcode == 0x67:  # JALR
+            imm = self._sign_extend(instr >> 20, 12)
+            self.regs[rd] = (self.pc + 4) & 0xFFFFFFFFFFFFFFFF
+            next_pc = (self.regs[rs1] + imm) & 0xFFFFFFFFFFFFFFFE
+        elif opcode == 0x2F:  # Atomic memory ops
+            funct5 = (instr >> 27) & 0x1F
+            aq    = (instr >> 26) & 1
+            rl    = (instr >> 25) & 1
+            addr = self.regs[rs1]
+            if funct5 == 0x02:  # LR.D
+                self.regs[rd] = self.mem.get(addr, 0)
+                self._reservation = addr
+            elif funct5 == 0x03:  # SC.D
+                if self._reservation == addr:
+                    self.mem[addr] = self.regs[rs2] & 0xFFFFFFFFFFFFFFFF
+                    self.regs[rd] = 0
+                else:
+                    self.regs[rd] = 1
+                self._reservation = None
+            elif funct5 == 0x00:  # AMOADD.D
+                tmp = self.mem.get(addr, 0)
+                self.mem[addr] = (tmp + self.regs[rs2]) & 0xFFFFFFFFFFFFFFFF
+                self.regs[rd] = tmp
+            elif funct5 == 0x01:  # AMOSWAP.D
+                tmp = self.mem.get(addr, 0)
+                self.mem[addr] = self.regs[rs2] & 0xFFFFFFFFFFFFFFFF
+                self.regs[rd] = tmp
         self.pc = next_pc
         return next_pc
 

--- a/tb/tests/test_golden_model.py
+++ b/tb/tests/test_golden_model.py
@@ -1,5 +1,89 @@
+import os
+import sys
 import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 from rtl.isa.golden_model import GoldenModel
+
+
+def encode_branch(funct3, rs1, rs2, imm):
+    imm &= 0x1FFF
+    return (
+        ((imm >> 12) & 1) << 31
+        | ((imm >> 5) & 0x3F) << 25
+        | (rs2 & 0x1F) << 20
+        | (rs1 & 0x1F) << 15
+        | (funct3 & 7) << 12
+        | ((imm >> 1) & 0xF) << 8
+        | ((imm >> 11) & 1) << 7
+        | 0x63
+    )
+
+
+def encode_jal(rd, imm):
+    imm &= 0x1FFFFF
+    return (
+        ((imm >> 20) & 1) << 31
+        | ((imm >> 1) & 0x3FF) << 21
+        | ((imm >> 11) & 1) << 20
+        | ((imm >> 12) & 0xFF) << 12
+        | (rd & 0x1F) << 7
+        | 0x6F
+    )
+
+
+def encode_jalr(rd, rs1, imm):
+    imm &= 0xFFF
+    return (
+        (imm & 0xFFF) << 20
+        | (rs1 & 0x1F) << 15
+        | 0 << 12
+        | (rd & 0x1F) << 7
+        | 0x67
+    )
+
+
+def encode_lr(rd, rs1):
+    return (
+        (0x02 << 27)
+        | (rs1 & 0x1F) << 15
+        | (0x3 << 12)
+        | (rd & 0x1F) << 7
+        | 0x2F
+    )
+
+
+def encode_sc(rd, rs1, rs2):
+    return (
+        (0x03 << 27)
+        | (rs2 & 0x1F) << 20
+        | (rs1 & 0x1F) << 15
+        | (0x3 << 12)
+        | (rd & 0x1F) << 7
+        | 0x2F
+    )
+
+
+def encode_amoadd(rd, rs1, rs2):
+    return (
+        (0x00 << 27)
+        | (rs2 & 0x1F) << 20
+        | (rs1 & 0x1F) << 15
+        | (0x3 << 12)
+        | (rd & 0x1F) << 7
+        | 0x2F
+    )
+
+
+def encode_amoswap(rd, rs1, rs2):
+    return (
+        (0x01 << 27)
+        | (rs2 & 0x1F) << 20
+        | (rs1 & 0x1F) << 15
+        | (0x3 << 12)
+        | (rd & 0x1F) << 7
+        | 0x2F
+    )
 
 class GoldenModelTest(unittest.TestCase):
     def test_add_and_addi(self):
@@ -21,6 +105,58 @@ class GoldenModelTest(unittest.TestCase):
         self.assertEqual(gm.pc, 12)
         gm.step(0x00000463)  # beq x0,x0,8 -> taken
         self.assertEqual(gm.pc, 20)
+
+    def test_mul_div_rem(self):
+        gm = GoldenModel()
+        gm.step(0x00A00093)  # addi x1,x0,10
+        gm.step(0x00500113)  # addi x2,x0,5
+        gm.step(0x022081b3)  # mul x3,x1,x2 -> 50
+        gm.step(0x0211c233)  # div x4,x3,x1 -> 5
+        gm.step(0x0221e2b3)  # rem x5,x3,x2 -> 0
+        self.assertEqual(gm.regs[3], 50)
+        self.assertEqual(gm.regs[4], 5)
+        self.assertEqual(gm.regs[5], 0)
+
+    def test_jal_and_jalr(self):
+        gm = GoldenModel()
+        gm.step(encode_jal(1, 8))  # jal x1,8
+        self.assertEqual(gm.pc, 8)
+        self.assertEqual(gm.regs[1], 4)
+        gm.regs[5] = 100
+        gm.step(encode_jalr(2, 5, 4))  # jalr x2,x5,4
+        self.assertEqual(gm.pc, 104)
+        self.assertEqual(gm.regs[2], 12)
+
+    def test_blt_bge(self):
+        gm = GoldenModel()
+        gm.regs[1] = 5
+        gm.regs[2] = 10
+        gm.step(encode_branch(0x4, 1, 2, 4))  # blt x1,x2,4
+        self.assertEqual(gm.pc, 4)
+        gm.step(encode_branch(0x5, 2, 1, 4))  # bge x2,x1,4
+        self.assertEqual(gm.pc, 8)
+
+    def test_lr_sc_and_amo(self):
+        gm = GoldenModel()
+        gm.regs[2] = 0x100
+        gm.load_memory(0x100, 5)
+        gm.step(encode_lr(1, 2))  # lr.d x1,(x2)
+        self.assertEqual(gm.regs[1], 5)
+        gm.regs[3] = 7
+        gm.step(encode_sc(4, 2, 3))  # sc.d x3,(x2)
+        self.assertEqual(gm.regs[4], 0)
+        self.assertEqual(gm.mem[0x100], 7)
+        gm.regs[3] = 9
+        gm.regs[2] = 0x108
+        gm.step(encode_sc(4, 2, 3))  # sc.d should fail
+        self.assertEqual(gm.regs[4], 1)
+        gm.regs[2] = 0x100
+        gm.step(encode_amoadd(5, 2, 3))  # amoadd.d x5,(x2),x3
+        self.assertEqual(gm.regs[5], 7)
+        self.assertEqual(gm.mem[0x100], 16)
+        gm.step(encode_amoswap(6, 2, 3))  # amoswap.d x6,(x2),x3
+        self.assertEqual(gm.regs[6], 16)
+        self.assertEqual(gm.mem[0x100], 9)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- document amo_unit and reference it from module listings
- implement amo_unit execution module
- expand golden model with LR/SC and AMOADD/AMOSWAP
- update tests for new atomic operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68415b51322083268450ad1f5d5fbc79