### PR TITLE
Fix duplicate modules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,5 @@ Implemented modules so far:
 - `dram_model` – tiny backing memory model
 - `core_tile_2smts_8wide` – wrapper for two-thread core
 - `riscv_soc_4core` – four-core SoC top
-- `int_alu2` – dual one-cycle integer ALU pipelines
-- `muldiv_unit` – pipelined multiply/divide unit
-- `branch_unit` – resolves branches and detects mispredictions
-- `amo_unit` – executes basic atomic operations
 
 Development follows the tasks outlined in `docs/tasks/cpu.txt`.


### PR DESCRIPTION
## Summary
- dedupe `int_alu2`, `muldiv_unit`, `branch_unit` and `amo_unit` entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841785b822083269ebd8985b60bdfba