### PR TITLE
Add page walker8 and L3 cache modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Implemented modules so far:
 - `l2_cache_1m_8w` – stub L2 cache model
 - `tlb_l2_512e_8w` – level-2 TLB
 - `page_walker` – simple page table walker
+- `page_walker8` – multi-request page walker
 - `ex_stage` – wrapper that routes issued µops to functional units
 - `smt_arbitration` – round-robin scheduler for SMT threads
 - `router_5port` – simple five-port mesh router
 - `l3_slice_4m_8w` – placeholder L3 cache slice
+- `l3_cache_16m_8w` – shared L3 cache
 - `nx_check` – no-execute permission checker
 - `vmcs` – virtualization control structure
 - `ept` – extended page table translator

--- a/docs/branch_predictor_top.md
+++ b/docs/branch_predictor_top.md
@@ -1,13 +1,10 @@
 # branch_predictor_top Module
 
 `branch_predictor_top.sv` integrates several prediction structures: a return
-stack buffer, a BTB, a small TAGE predictor and an indirect branch predictor.
-The module selects the next PC based on instruction type information from the
-decode stage and receives update information when branches retire.
-
-`branch_predictor_top.sv` implements a tiny branch prediction unit. It keeps a
-small branch target buffer (BTB) indexed by bits of the program counter and a
-2‑bit saturating counter per entry.
+stack buffer (RSB), a branch target buffer (BTB) with 2‑bit saturating
+counters, a small TAGE predictor and an indirect branch predictor. The module
+selects the next PC based on decode information and updates predictor state when
+branches retire.
 
 
 ## Parameters
@@ -55,18 +52,3 @@ On branch retirement the BTB, TAGE and IBP tables are updated with the actual
 outcome and target. Calls push the return address onto the RSB and returns pop
 it.
 
-| `pc_i` | in | 64 | Program counter for lookup |
-| `predicted_taken_o` | out | 1 | Predicted taken flag |
-| `predicted_target_o` | out | 64 | Predicted target address |
-| `update_valid_i` | in | 1 | Apply an update |
-| `update_pc_i` | in | 64 | PC of executed branch |
-| `update_taken_i` | in | 1 | Actual branch taken flag |
-| `update_target_i` | in | 64 | Actual branch target |
-
-## Behavior
-
-On each cycle the predictor indexes its BTB using bits of `pc_i`. If the stored
-tag matches, it outputs the saved target address and the high bit of the
-counter as the taken prediction. When `update_valid_i` is asserted, the entry
-indexed by `update_pc_i` is updated with the actual outcome and target and the
-counter is incremented or decremented with saturation.

--- a/rtl/interconnect/__init__.py
+++ b/rtl/interconnect/__init__.py
@@ -1,0 +1,4 @@
+from .dram_model import DRAMModel
+from .l3_slice_4m_8w import L3Slice
+from .router_5port import Router5Port
+from .l3_cache_16m_8w import L3Cache16M8W

--- a/rtl/interconnect/l3_cache_16m_8w.py
+++ b/rtl/interconnect/l3_cache_16m_8w.py
@@ -1,0 +1,11 @@
+class L3Cache16M8W:
+    """Very small model of a shared L3 cache implemented as a dictionary."""
+
+    def __init__(self):
+        self.mem = {}
+
+    def read(self, addr):
+        return self.mem.get(addr, 0)
+
+    def write(self, addr, data):
+        self.mem[addr] = data

--- a/rtl/interconnect/l3_cache_16m_8w.sv
+++ b/rtl/interconnect/l3_cache_16m_8w.sv
@@ -1,0 +1,39 @@
+// l3_cache_16m_8w.sv - Simplified shared L3 cache (16 MB)
+//
+// For now this model behaves like a large backing memory with a single cycle
+// response. Directory and coherence logic are omitted.
+
+module l3_cache_16m_8w (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        req_valid_i,
+    input  logic [63:0] req_addr_i,
+    input  logic        req_write_i,
+    input  logic [63:0] req_wdata_i,
+    input  logic        resp_ready_i,
+    output logic        resp_valid_o,
+    output logic [63:0] resp_rdata_o
+);
+
+    logic [63:0] mem [0:4095];
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            resp_valid_o <= 1'b0;
+            resp_rdata_o <= 64'd0;
+        end else begin
+            if (req_valid_i && resp_ready_i) begin
+                resp_valid_o <= 1'b1;
+                if (req_write_i) begin
+                    mem[req_addr_i[15:3]] <= req_wdata_i;
+                    resp_rdata_o <= 64'd0;
+                end else begin
+                    resp_rdata_o <= mem[req_addr_i[15:3]];
+                end
+            end else begin
+                resp_valid_o <= 1'b0;
+            end
+        end
+    end
+
+endmodule

--- a/rtl/mmu/README.md
+++ b/rtl/mmu/README.md
@@ -1,3 +1,7 @@
-MMU-related modules including instruction and data TLBs and page walker logic.
-This directory currently contains a simple L1 TLB placeholder used by the
-fetch and LSU stages.
+MMU-related modules including instruction and data TLBs and page walker logic. The RTL models here are simplified behavioral placeholders.
+
+Available modules:
+- `tlb_l1_64e_8w` – small 64-entry TLB
+- `tlb_l2_512e_8w` – larger second-level TLB
+- `page_walker` – single-request page table walker
+- `page_walker8` – up to 8 in-flight walk requests

--- a/rtl/mmu/__init__.py
+++ b/rtl/mmu/__init__.py
@@ -1,3 +1,4 @@
 from .tlb_l1 import TlbL1
 from .tlb_l2 import TlbL2
 from .page_walker import PageWalker
+from .page_walker8 import PageWalker8

--- a/rtl/mmu/page_walker8.py
+++ b/rtl/mmu/page_walker8.py
@@ -1,0 +1,16 @@
+class PageWalker8:
+    """Simple page walker model that maps virtual addresses to physical addresses.
+    A dictionary is used for all entries and lookups complete immediately."""
+
+    def __init__(self):
+        self.table = {}
+
+    def set_entry(self, va, pa, perm='rw'):
+        self.table[va] = (pa, perm)
+
+    def walk(self, va, perm='r'):
+        if va not in self.table:
+            return 0, True
+        pa, permissions = self.table[va]
+        fault = perm not in permissions
+        return pa, fault

--- a/rtl/mmu/page_walker8.sv
+++ b/rtl/mmu/page_walker8.sv
@@ -1,0 +1,49 @@
+// page_walker8.sv - Simplified page table walker supporting up to 8 concurrent requests
+//
+// Each request is translated using an internal associative array. This model
+// returns a result in a single cycle and does not perform real page table walks.
+
+module page_walker8 (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic  [7:0] walk_valid_i,
+    input  logic [63:0] walk_vaddr_i [8],
+    input  logic  [2:0] walk_perm_i  [8],
+    output logic  [7:0] walk_ready_o,
+    output logic  [7:0] resp_valid_o,
+    output logic [63:0] resp_paddr_o [8],
+    output logic  [7:0] resp_fault_o
+);
+
+    typedef struct packed {
+        logic        valid;
+        logic [63:0] vaddr;
+        logic [63:0] paddr;
+        logic [2:0]  perm;
+    } entry_t;
+
+    entry_t table [16];
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (int i = 0; i < 16; i++) table[i].valid <= 1'b0;
+        end
+    end
+
+    // Simple lookup per request
+    always_comb begin
+        for (int k = 0; k < 8; k++) begin
+            resp_valid_o[k] = 1'b0;
+            resp_paddr_o[k] = 64'd0;
+            resp_fault_o[k] = 1'b0;
+            walk_ready_o[k] = 1'b1;
+            for (int i = 0; i < 16; i++) begin
+                if (table[i].valid && table[i].vaddr == walk_vaddr_i[k]) begin
+                    resp_valid_o[k] = walk_valid_i[k];
+                    resp_paddr_o[k] = table[i].paddr;
+                    resp_fault_o[k] = |(walk_perm_i[k] & ~table[i].perm);
+                end
+            end
+        end
+    end
+endmodule

--- a/tb/tests/test_l3_cache.py
+++ b/tb/tests/test_l3_cache.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from rtl.interconnect.l3_cache_16m_8w import L3Cache16M8W
+
+class L3Cache16M8WTest(unittest.TestCase):
+    def test_read_write(self):
+        cache = L3Cache16M8W()
+        cache.write(0x40, 42)
+        self.assertEqual(cache.read(0x40), 42)
+        self.assertEqual(cache.read(0x80), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tb/tests/test_page_walker8.py
+++ b/tb/tests/test_page_walker8.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from rtl.mmu.page_walker8 import PageWalker8
+
+class PageWalker8Test(unittest.TestCase):
+    def test_walk(self):
+        pw = PageWalker8()
+        va = 0x1000
+        pw.set_entry(va, 0x80001000, perm='rwx')
+        pa, fault = pw.walk(va, perm='r')
+        self.assertEqual(pa, 0x80001000)
+        self.assertFalse(fault)
+        pa, fault = pw.walk(va, perm='w')
+        self.assertFalse(fault)
+        miss_pa, miss_fault = pw.walk(0x2000)
+        self.assertTrue(miss_fault)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new multi-request page walker module (`page_walker8`) and simple model
- implement placeholder 16 MB L3 cache and Python model
- expose new modules in package inits and docs
- test new components with unit tests
- clean up duplicate text in `branch_predictor_top.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841793230d083268b8ca163c7a42beb