### PR TITLE
Cleanup scoreboard and tests

### DIFF
--- a/tb/tests/test_scoreboard.py
+++ b/tb/tests/test_scoreboard.py
@@ -4,6 +4,55 @@ import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 from tb.uvm_components import Scoreboard
+from tb.uvm_components.coverage import CoverageModel
+from rtl.isa.golden_model import GoldenModel
+
+
+def encode_branch(funct3, rs1, rs2, imm):
+    imm &= 0x1FFF
+    return (
+        ((imm >> 12) & 1) << 31
+        | ((imm >> 5) & 0x3F) << 25
+        | (rs2 & 0x1F) << 20
+        | (rs1 & 0x1F) << 15
+        | (funct3 & 7) << 12
+        | ((imm >> 1) & 0xF) << 8
+        | ((imm >> 11) & 1) << 7
+        | 0x63
+    )
+
+
+def encode_store(funct3, rs1, rs2, imm):
+    imm &= 0xFFF
+    return (
+        ((imm >> 5) & 0x7F) << 25
+        | (rs2 & 0x1F) << 20
+        | (rs1 & 0x1F) << 15
+        | (funct3 & 7) << 12
+        | (imm & 0x1F) << 7
+        | 0x23
+    )
+
+
+def encode_load(funct3, rd, rs1, imm):
+    imm &= 0xFFF
+    return (
+        (imm & 0xFFF) << 20
+        | (rs1 & 0x1F) << 15
+        | (funct3 & 7) << 12
+        | (rd & 0x1F) << 7
+        | 0x03
+    )
+
+
+def encode_csrrwi(rd, imm, csr):
+    return (
+        (csr & 0xFFF) << 20
+        | (imm & 0x1F) << 15
+        | (0x5 << 12)
+        | (rd & 0x1F) << 7
+        | 0x73
+    )
 
 
 class ScoreboardTest(unittest.TestCase):
@@ -21,81 +70,20 @@ class ScoreboardTest(unittest.TestCase):
         sb.add_actual(2)
         self.assertFalse(sb.check())
 
-from tb.uvm_components.coverage import CoverageModel
-
-from rtl.isa.golden_model import GoldenModel
-
-
-def encode_branch(funct3, rs1, rs2, imm):
-    imm &= 0x1FFF
-    return (
-        ((imm >> 12) & 1) << 31
-        | ((imm >> 5) & 0x3F) << 25
-        | (rs2 & 0x1F) << 20
-        | (rs1 & 0x1F) << 15
-        | (funct3 & 7) << 12
-        | ((imm >> 1) & 0xF) << 8
-        | ((imm >> 11) & 1) << 7
-        | 0x63
-    )
-def encode_store(funct3, rs1, rs2, imm):
-    imm &= 0xFFF
-    return (
-        ((imm >> 5) & 0x7F) << 25
-        | (rs2 & 0x1F) << 20
-        | (rs1 & 0x1F) << 15
-        | (funct3 & 7) << 12
-        | (imm & 0x1F) << 7
-        | 0x23
-    )
-
-def encode_load(funct3, rd, rs1, imm):
-    imm &= 0xFFF
-    return (
-        (imm & 0xFFF) << 20
-        | (rs1 & 0x1F) << 15
-        | (funct3 & 7) << 12
-        | (rd & 0x1F) << 7
-        | 0x03
-    )
-
-def encode_csrrwi(rd, imm, csr):
-    return (
-        (csr & 0xFFF) << 20
-        | (imm & 0x1F) << 15
-        | (0x5 << 12)
-        | (rd & 0x1F) << 7
-        | 0x73
-    )
-
-class ScoreboardTest(unittest.TestCase):
     def test_commit_sequence(self):
         sb = Scoreboard()
         sb.gm.mem[0x100] = 0
-
-class ScoreboardTest(unittest.TestCase):
-    def test_commit_sequence(self):
-        sb = Scoreboard()
-
-        # ADDI x1,x0,5
         self.assertTrue(sb.commit(0x00500093, rd_arch=1, rd_val=5, next_pc=4))
-        # ADDI x2,x0,0x100
         self.assertTrue(sb.commit(0x10000113, rd_arch=2, rd_val=0x100, next_pc=8))
-        # ADD x3,x1,x2 -> 0x105
         self.assertTrue(sb.commit(0x002081b3, rd_arch=3, rd_val=0x105, next_pc=12))
-        # Store x3 to 0x100
-        sb.commit(0x00312023, is_store=True, store_addr=0x100, store_data=0x105,
-                   next_pc=16)
-        # Load into x4
+        sb.commit(0x00312023, is_store=True, store_addr=0x100, store_data=0x105, next_pc=16)
         gm = GoldenModel()
         gm.step(0x00500093)
         gm.step(0x10000113)
         gm.step(0x002081b3)
         gm.mem[0x100] = 0x105
         expected = gm.mem.get(0x100, 0)
-        # ld x4,0(x2)
-        self.assertTrue(sb.commit(0x00013203, rd_arch=4, rd_val=expected,
-                                   next_pc=20))
+        self.assertTrue(sb.commit(0x00013203, rd_arch=4, rd_val=expected, next_pc=20))
         trace = sb.get_trace()
         self.assertEqual(len(trace), 5)
         self.assertEqual(trace[0]["pc"], 0)
@@ -106,9 +94,7 @@ class ScoreboardTest(unittest.TestCase):
     def test_branch_pc(self):
         sb = Scoreboard()
         sb.gm.mem[0x200] = 0
-
-        # JAL to PC+8 at PC=0
-        self.assertTrue(sb.commit(0x0080006f, next_pc=8))
+        self.assertTrue(sb.commit(0x0080006F, next_pc=8))
         trace = sb.get_trace()
         self.assertEqual(trace[0]["cycle"], 0)
 
@@ -127,7 +113,6 @@ class ScoreboardTest(unittest.TestCase):
             pred_target_list=[None, None],
             mispredict_list=[False, False],
             rob_idx_list=[0, 1],
-
         )
         self.assertEqual(results, [True, True])
         trace = sb.get_trace()
@@ -140,9 +125,7 @@ class ScoreboardTest(unittest.TestCase):
         sb = Scoreboard()
         self.assertTrue(sb.commit(0x00500093, rd_arch=1, rd_val=5, next_pc=4, rob_idx=0))
         self.assertTrue(sb.commit(0x00300113, rd_arch=2, rd_val=3, next_pc=8, rob_idx=1))
-        # Out-of-order commit should fail
         self.assertFalse(sb.commit(0x00000013, rd_arch=0, rd_val=0, next_pc=12, rob_idx=1))
-
 
     def test_reset(self):
         sb = Scoreboard()
@@ -154,8 +137,7 @@ class ScoreboardTest(unittest.TestCase):
 
     def test_illegal_exception(self):
         sb = Scoreboard()
-        # 0xffffffff is not a valid instruction
-        self.assertTrue(sb.commit(0xffffffff, exception="illegal"))
+        self.assertTrue(sb.commit(0xFFFFFFFF, exception="illegal"))
         trace = sb.get_trace()
         self.assertEqual(trace[0]["exception"], "illegal")
 
@@ -168,13 +150,7 @@ class ScoreboardTest(unittest.TestCase):
 
     def test_page_fault_exception(self):
         sb = Scoreboard()
-        # access unmapped memory at 0x500
-        self.assertTrue(
-            sb.commit(
-                encode_load(0x3, 1, 0, 0x500),
-                exception="page",
-            )
-        )
+        self.assertTrue(sb.commit(encode_load(0x3, 1, 0, 0x500), exception="page"))
         self.assertTrue(
             sb.commit(
                 encode_store(0x3, 0, 1, 0x500),
@@ -188,28 +164,13 @@ class ScoreboardTest(unittest.TestCase):
     def test_byte_load_store(self):
         sb = Scoreboard()
         sb.gm.mem[0x200] = 0
-
-    def test_byte_load_store(self):
-        sb = Scoreboard()
-
-        # addi x1,x0,0x200
         self.assertTrue(sb.commit(0x20000093, rd_arch=1, rd_val=0x200, next_pc=4))
-        # addi x2,x0,0xAA
         self.assertTrue(sb.commit(0x0AA00113, rd_arch=2, rd_val=0xAA, next_pc=8))
-        # sb x2,0(x1)
-
         sb.commit(encode_store(0x0, 1, 2, 0), is_store=True, store_addr=0x200, store_data=0xAA, next_pc=12)
-        # lb x3,0(x1)
         self.assertTrue(sb.commit(encode_load(0x0, 3, 1, 0), rd_arch=3, rd_val=0xFFFFFFFFFFFFFFAA, next_pc=16))
-
-        sb.commit(0x00210023, is_store=True, store_addr=0x200, store_data=0xAA, next_pc=12)
-        # lb x3,0(x1)
-        self.assertTrue(sb.commit(0x00010183, rd_arch=3, rd_val=0xFFFFFFFFFFFFFFAA, next_pc=16))
-
 
     def test_load_data_check(self):
         sb = Scoreboard()
-        # addi x1,x0,0x300
         self.assertTrue(sb.commit(0x30000093, rd_arch=1, rd_val=0x300, next_pc=4))
         sb.gm.mem[0x300] = 0x1122334455667788
         ld_instr = encode_load(0x3, 2, 1, 0)
@@ -227,7 +188,6 @@ class ScoreboardTest(unittest.TestCase):
 
     def test_branch_prediction(self):
         sb = Scoreboard()
-        # beq x0,x0,+8 (taken)
         instr = encode_branch(0x0, 0, 0, 8)
         self.assertTrue(
             sb.commit(
@@ -240,8 +200,7 @@ class ScoreboardTest(unittest.TestCase):
                 next_pc=8,
             )
         )
-        # Another branch mispredicted
-        instr2 = encode_branch(0x1, 0, 0, 8)  # bne x0,x0,+8 -> not taken
+        instr2 = encode_branch(0x1, 0, 0, 8)
         self.assertTrue(
             sb.commit(
                 instr2,
@@ -254,13 +213,11 @@ class ScoreboardTest(unittest.TestCase):
             )
         )
 
-
     def test_csr_commit(self):
         sb = Scoreboard()
         instr = encode_csrrwi(1, 2, 0x300)
         self.assertTrue(sb.commit(instr, rd_arch=1, rd_val=0, next_pc=4))
         self.assertEqual(sb.gm.csrs.get(0x300), 2)
-
 
     def test_dump_trace(self):
         sb = Scoreboard()
@@ -277,8 +234,7 @@ class ScoreboardTest(unittest.TestCase):
         cov = CoverageModel()
         sb = Scoreboard(coverage=cov)
         sb.commit(0x00500093, rd_arch=1, rd_val=5, next_pc=4)
-        sb.commit(0xffffffff, exception="illegal")
-        # branch predicted correctly
+        sb.commit(0xFFFFFFFF, exception="illegal")
         sb.commit(
             encode_branch(0x0, 0, 0, 8),
             branch_taken=True,
@@ -288,7 +244,6 @@ class ScoreboardTest(unittest.TestCase):
             mispredict=False,
             next_pc=8,
         )
-        # mispredicted branch
         sb.commit(
             encode_branch(0x1, 0, 0, 8),
             branch_taken=False,
@@ -299,14 +254,11 @@ class ScoreboardTest(unittest.TestCase):
             next_pc=12,
         )
         summary = cov.summary()
-        self.assertEqual(summary['opcodes'], 3)
-        self.assertEqual(summary['exceptions']['illegal'], 1)
-        self.assertEqual(summary['branches'], 2)
-        self.assertEqual(summary['mispredicts'], 1)
-
-        self.assertTrue(lines[0].startswith("cycle"))
-        self.assertEqual(len(lines), 2)
+        self.assertEqual(summary["opcodes"], 3)
+        self.assertEqual(summary["exceptions"]["illegal"], 1)
+        self.assertEqual(summary["branches"], 2)
+        self.assertEqual(summary["mispredicts"], 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- refactor `Scoreboard` implementation
- clean up `test_scoreboard` and remove duplicated tests
- ensure byte load/store test initializes memory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423e67116c832689054ce99e7ec1e5